### PR TITLE
Big Ol' SheetManager Refactor

### DIFF
--- a/SheetManager.py
+++ b/SheetManager.py
@@ -26,85 +26,184 @@ class SheetManager(object):
         self.out_file = path.expanduser(out_file)
 
         # Required files
-        master_csv_path = path.expanduser(self._master_config.location)
-        child_csv_path = path.expanduser(self._child_config.location)
+        self._master_csv_path = path.expanduser(self._master_config.location)
+        self._child_csv_path = path.expanduser(self._child_config.location)
 
         # Sheet Existence validation
-        for f in {master_csv_path, child_csv_path}:
+        for f in {self._master_csv_path, self._child_csv_path}:
             if path.isfile(f):
                 print('Found file: {}'.format(f))
             else:
                 raise SheetManagerException('{} is not a file.'.format(f))
 
-        self.master_reader = csv.DictReader(open(master_csv_path))
-        self.child_reader = csv.DictReader(open(child_csv_path))
+        self.master_reader = self._initialize_csv_reader(self._master_csv_path)
+        self.child_reader = self._initialize_csv_reader(self._child_csv_path)
+        self.child_reader.fieldnames = self._make_child_fieldnames_unique()
+
+    @staticmethod
+    def _initialize_csv_reader(file_path):
+        return csv.DictReader(open(file_path))
+
+    def _make_child_fieldnames_unique(self):
+        """ Disallows duplicate column headers between Master and Child by adding a suffix where needed """
+        unique_fieldnames = list()
+        for name in self.child_reader.fieldnames:
+            if name in self.master_reader.fieldnames and name != self._child_config.id_column:
+                name += '__1'
+            unique_fieldnames.append(name)
+        return unique_fieldnames
 
     def merge(self):
-        """ Merge child into master using match_column """
+        """
+        Merge child into master using match_column
 
-        remaining_child_rows = list()
-        unwanted_child_ids = list()
-        aligned_count = 0
-
-        # Hold all children in memory
-        total_children = 0
-        for row in self.child_reader:
-            total_children += 1
-
-            # Only add child if its ID len matches the master config length!
-            child_id = row[self._child_config.id_column]
-            if len(self._normalize_uid(child_id)) == self._master_config.id_char_count:
-                remaining_child_rows.append(row)
-            else:
-                unwanted_child_ids.append(child_id)
-
-        print(SEP)
-        print('Total child rows processed: {}'.format(total_children))
-        print('    Child rows with proper ID lengths: {}'.format(len(remaining_child_rows)))
-        print('    Child rows with incorrect ID lengths: {}'.format(len(unwanted_child_ids)))
-        print(SEP)
+        The mental gymnastics here broke my fucking brain.
+        """
 
         output_fieldnames = self.master_reader.fieldnames + self.child_reader.fieldnames
-        with open(self.out_file, 'w') as out:
-            print('Writing out to: {}'.format(self.out_file))
-            output_writer = csv.DictWriter(out, output_fieldnames)
 
-            # Initialize output CSV
-            output_writer.writeheader()
+        unwanted_child_ids = list()
 
-            # Iterate through master rows
-            for m_row in self.master_reader:
-                out_dict = deepcopy(m_row)
-                master_id = m_row[self._master_config.id_column]
+        finished = False
+        while not finished:
 
-                # Iterate through remaining children
-                for c_row in remaining_child_rows:
-                    child_id = c_row[self._child_config.id_column]
+            # This is a flag that instructs nested loops to break one after the other. Very ugly. Do not like.
+            start_over = False
 
-                    # Do the IDs match after normalization?
-                    n_child_id = self._normalize_uid(uid=child_id)
-                    n_master_id = self._normalize_uid(uid=master_id, actual_id_len=self._master_config.id_char_count)
-                    if n_child_id == n_master_id:
-                        aligned_count += 1
-                        if self.verbose:
-                            print('    ID match: {}'.format(master_id))
+            # Reset everything every time this loop is kicked off for a fresh start
+            remaining_child_rows = list()
+            unwanted_child_ids = list()
+            aligned_count = 0
 
-                        # Add all children values to out_dict
-                        for c_key, c_value in c_row.items():
-                            out_dict[c_key] = c_value
+            # Hold all children in memory
+            total_children = 0
+            for row in self.child_reader:
+                total_children += 1
 
-                        # Delete child from remaining children so it is never iterated over again
-                        remaining_child_rows.remove(c_row)
+                # Only add child if its ID len matches the master config length!
+                child_id = row[self._child_config.id_column]
+                if len(self._normalize_uid(child_id)) == self._master_config.id_char_count:
+                    remaining_child_rows.append(row)
+                else:
+                    unwanted_child_ids.append(child_id)
 
-                # Write completed out_dict to the output CSV file
-                output_writer.writerow(out_dict)
+            print(SEP)
+            print('Total child rows processed: {}'.format(total_children))
+            print('    Child rows with proper ID lengths: {}'.format(len(remaining_child_rows)))
+            print('    Child rows with incorrect ID lengths: {}'.format(len(unwanted_child_ids)))
+            print(SEP)
 
-            print('Rows aligned by {}: {}'.format(self._master_config.id_column, aligned_count))
+            with open(self.out_file, 'w') as out:
+                print('Writing out to: {}'.format(self.out_file))
+                output_writer = csv.DictWriter(out, output_fieldnames)
 
-            # Don't forget the orphan children!
-            print('Unmatched child rows appended to the end of the file: {}'.format(len(remaining_child_rows)))
-            for o_row in remaining_child_rows:
-                output_writer.writerow(o_row)
+                # Initialize output CSV
+                output_writer.writeheader()
+
+                # Iterate through master rows
+                for m_row in self.master_reader:
+
+                    if start_over:
+                        break
+
+                    out_dict = deepcopy(m_row)
+                    # Pre-initialize out_dict with the most up-to-date output_fieldnames
+                    for name in output_fieldnames:
+                        if name not in out_dict.keys():
+                            out_dict[name] = ''
+
+                    master_id = m_row[self._master_config.id_column]
+
+                    # Iterate through remaining children
+                    for c_row in remaining_child_rows:
+
+                        if start_over:
+                            break
+
+                        child_id = c_row[self._child_config.id_column]
+
+                        # Do the IDs match after normalization?
+                        n_child_id = self._normalize_uid(uid=child_id)
+                        n_master_id = self._normalize_uid(uid=master_id, actual_id_len=self._master_config.id_char_count)
+                        if n_child_id == n_master_id:
+                            aligned_count += 1
+                            if self.verbose:
+                                print('    ID match: {}'.format(master_id))
+
+                            # Add all children values to out_dict
+                            for c_key, c_value in c_row.items():
+
+                                if start_over:
+                                    break
+
+                                # TODO: The following while loop and the if statement immediately after may be able to
+                                #   be consolidated into one, but I'm not screwing around with it right now.
+
+                                # Don't override existing information!
+                                while c_key in m_row.keys():
+                                    if c_key == self._child_config.id_column:
+                                        break
+                                    else:
+                                        c_key = self.__increment_key(c_key)
+
+                                    # Missing key means the dictWriter must be re-initialized with the key added.
+                                    if c_key not in output_fieldnames:
+                                        if self.verbose:
+                                            print('    Key \'{}\' missing from Master. '
+                                                  'Adding and starting over...'.format(c_key))
+                                        output_fieldnames.append(c_key)
+                                        start_over = True
+                                        break
+
+                                # More than one child found for master row?
+                                if c_key in out_dict.keys() and c_key != self._child_config.id_column and len(out_dict[c_key]) > 0:
+
+                                    # Increment everything!
+                                    inserted = False
+                                    while c_key in out_dict.keys():
+                                        c_key = self.__increment_key(c_key)
+
+                                        # Found an empty, incremented cell...
+                                        if c_key in out_dict.keys() and len(out_dict[c_key]) == 0:
+
+                                            # Put it in there!
+                                            out_dict[c_key] = c_value
+                                            inserted = True
+                                            break
+
+                                    # Not being able to insert the value implies that the key needs to be added to
+                                    #   the dictWriter for re-initialization.
+                                    if not inserted:
+                                        if self.verbose:
+                                            print('    Adding key \'{}\' and starting over...'.format(c_key))
+                                        output_fieldnames.append(c_key)
+                                        start_over = True
+                                        break
+
+                                # Didn't encounter any of that nonsense above? Nice. Just shove it right in.
+                                out_dict[c_key] = c_value
+
+                            # Delete child from remaining children so it is never iterated over again
+                            remaining_child_rows.remove(c_row)
+
+                    # Write completed out_dict to the output CSV file
+                    output_writer.writerow(out_dict)
+
+                if start_over:
+                    if self.verbose:
+                        print('Re-initializing readers...')
+                    self.master_reader = self._initialize_csv_reader(self._master_csv_path)
+                    self.child_reader = self._initialize_csv_reader(self._child_csv_path)
+                    continue
+
+                print('Rows aligned by {}: {}'.format(self._master_config.id_column, aligned_count))
+
+                # Don't forget the orphan children!
+                print('Unmatched child rows appended to the end of the file: {}'.format(len(remaining_child_rows)))
+                for o_row in remaining_child_rows:
+                    output_writer.writerow(o_row)
+
+                finished = True
 
         # Display unmatched child IDs for verification
         if self.verbose:
@@ -115,6 +214,15 @@ class SheetManager(object):
 
     def prune(self):
         raise SheetManagerException('prune method not yet implemented')
+
+    @staticmethod
+    def __increment_key(key_name):
+        if '__' in key_name:
+            prefix, increment = key_name.rsplit('__', 1)
+            key_name = '{}__{}'.format(prefix, int(increment) + 1)
+        else:
+            key_name += '__1'
+        return key_name
 
     @staticmethod
     def _normalize_uid(uid, actual_id_len=None):

--- a/config/combined_king_children.json
+++ b/config/combined_king_children.json
@@ -1,0 +1,5 @@
+{
+	"location": "~/muad-dweeb/cw/data/combined_king_children.csv",
+	"id_column": "Parcel Number",
+	"id_char_count": 10
+}

--- a/config/merged_all_king.json
+++ b/config/merged_all_king.json
@@ -1,0 +1,5 @@
+{
+	"location": "~/muad-dweeb/cw/data/Merged All King Co - Apt 2-70 units (Cleaned).csv",
+	"id_column": "Parcel Number",
+	"id_char_count": 10
+}

--- a/manage_sheets.py
+++ b/manage_sheets.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 
     try:
         # Create sheet manager object
-        manager = SheetManager(master_config=master_config, child_config=child_config)
+        manager = SheetManager(master_config=master_config, child_config=child_config, verbose=verbose)
 
         # Perform the requested operation
         if operation == 'merge':


### PR DESCRIPTION
# Summary

Prevents existing cell data from being overwritten if a new sheet is merged into the existing sheet with shared column names.

This is ugly AF. There's certainly a better way to do this.